### PR TITLE
negate formula injection attacks in downloaded CSV files

### DIFF
--- a/system/database/DB_utility.php
+++ b/system/database/DB_utility.php
@@ -245,14 +245,21 @@ abstract class CI_DB_utility {
 		}
 
 		$out = substr($out, 0, -strlen($delim)).$newline;
-
+		$unsafe_chars=array('=','+','-','@');
+		
 		// Next blast through the result array and build out the rows
 		while ($row = $query->unbuffered_row('array'))
 		{
 			$line = array();
 			foreach ($row as $item)
 			{
-				$line[] = $enclosure.str_replace($enclosure, $enclosure.$enclosure, $item).$enclosure;
+				$first = $item[0];
+				$prepend='';
+				if (in_array($first, $unsafe_chars));
+					$prepend="\t";
+				}
+
+				$line[] = $enclosure.$prepend.str_replace($enclosure, $enclosure.$enclosure, trim($item)).$enclosure;
 			}
 			$out .= implode($delim, $line).$newline;
 		}


### PR DESCRIPTION
The current setup is vulnerable to CSV formula injection attacks, this negates it. However it might need to be configurable to allow cases where formulas are required. See below for further information:
https://www.contextis.com/blog/comma-separated-vulnerabilities
http://georgemauer.net/2017/10/07/csv-injection.html